### PR TITLE
s3 이용한 이미지 업로드 및 삭제 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ dependencies {
 
 	//gpt
 	implementation'com.openai:openai-java:0.21.0'
+
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
 }
 
 

--- a/src/main/java/com/culture/BAEUNDAY/config/AwsS3Config.java
+++ b/src/main/java/com/culture/BAEUNDAY/config/AwsS3Config.java
@@ -1,0 +1,34 @@
+package com.culture.BAEUNDAY.config;
+
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsS3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+
+    @Bean
+    public AmazonS3Client amazonS3() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey); //AWS에 접근하기 위한 자격 증명 설정
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard() //AWS S3 접근하기 위한 클라이언트 객체 생성
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+
+}

--- a/src/main/java/com/culture/BAEUNDAY/config/SecurityConfig.java
+++ b/src/main/java/com/culture/BAEUNDAY/config/SecurityConfig.java
@@ -11,7 +11,6 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;

--- a/src/main/java/com/culture/BAEUNDAY/domain/user/DTO/request/UpdateFieldRequestDTO.java
+++ b/src/main/java/com/culture/BAEUNDAY/domain/user/DTO/request/UpdateFieldRequestDTO.java
@@ -1,0 +1,11 @@
+package com.culture.BAEUNDAY.domain.user.DTO.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Range;
+
+public record UpdateFieldRequestDTO(
+        @NotBlank(message = "필수 입력 항목입니다.")
+        String field
+) {
+}

--- a/src/main/java/com/culture/BAEUNDAY/domain/user/DTO/request/UpdateNameRequestDTO.java
+++ b/src/main/java/com/culture/BAEUNDAY/domain/user/DTO/request/UpdateNameRequestDTO.java
@@ -4,17 +4,12 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.Range;
 
-public record UpdateProfileRequestDTO(
-
-        @NotBlank(message = "이름은 필수 입력 항목입니다.")
+public record UpdateNameRequestDTO(
+        @NotBlank(message = "필수 입력 항목입니다.")
         String name,
-
-        @NotBlank(message = "한 줄 소개는 필수 입력 항목입니다.")
-        String field,
 
         @NotNull(message = "닉네임 중복 검사는 필수입니다.")
         @Range(min = 1, max = 1, message = "닉네임 중복 검사는 필수입니다.")
         Integer successName
 ) {
-
 }

--- a/src/main/java/com/culture/BAEUNDAY/domain/user/DTO/response/ImageResponseDTO.java
+++ b/src/main/java/com/culture/BAEUNDAY/domain/user/DTO/response/ImageResponseDTO.java
@@ -1,0 +1,10 @@
+package com.culture.BAEUNDAY.domain.user.DTO.response;
+
+import lombok.Builder;
+
+@Builder
+public record ImageResponseDTO(
+        String name,
+        String profileImg
+) {
+}

--- a/src/main/java/com/culture/BAEUNDAY/domain/user/ImageService.java
+++ b/src/main/java/com/culture/BAEUNDAY/domain/user/ImageService.java
@@ -1,0 +1,159 @@
+package com.culture.BAEUNDAY.domain.user;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.*;
+import com.culture.BAEUNDAY.domain.user.DTO.response.ImageResponseDTO;
+import com.culture.BAEUNDAY.jwt.Custom.CustomUserDetails;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ImageService {
+
+    private final AmazonS3 amazonS3;
+    private final UserService userService;
+
+    private static final String DEFAULT_IMAGE_URL = "https://baeunday.s3.ap-northeast-2.amazonaws.com/%EC%82%AC%EC%9A%A9%EC%9E%90+%EA%B8%B0%EB%B3%B8+%EC%9D%B4%EB%AF%B8%EC%A7%80.png";
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public ImageResponseDTO uploadImg(CustomUserDetails customUserDetails, String imageAddress, MultipartFile image) {
+
+        User user = userService.findUserByUsernameOrThrow(customUserDetails.getUsername());
+
+        if(image.isEmpty() || Objects.isNull(image.getOriginalFilename())) {
+            throw new IllegalArgumentException("파일이 비어 있거나 파일명이 없습니다.");
+        }
+
+        deleteImg(customUserDetails, imageAddress); //기존 이미지를 삭제하고
+        String ProfileImgAddress =  uploadImage(user, image); //새로운 이미지로 수정한다.
+
+        return ImageResponseDTO.builder()
+                .name(user.getName())
+                .profileImg(ProfileImgAddress)
+                .build();
+    }
+
+    private String uploadImage(User user, MultipartFile image) {
+
+        validateImageFileExtention(Objects.requireNonNull(image.getOriginalFilename()));
+
+        try {
+
+            String profileImageAddress = uploadImageToS3(image);
+            user.profileImg(profileImageAddress);
+
+            return profileImageAddress;
+
+
+        } catch (IOException e) {
+            throw new IllegalArgumentException("이미지를 저장하는데 실패하였습니다.");
+        }
+
+    }
+
+    private void validateImageFileExtention(String filename) {
+
+        int lastDotIndex = filename.lastIndexOf(".");
+        if (lastDotIndex == -1) {
+            throw new IllegalArgumentException("파일 확장자가 없습니다.");
+        }
+
+        String extention = filename.substring(lastDotIndex + 1).toLowerCase();
+        List<String> allowedExtentionList = Arrays.asList("jpg", "jpeg", "png", "gif");
+
+        if (!allowedExtentionList.contains(extention)) {
+            throw new IllegalArgumentException("파일 확장자가 올바르지 않습니다.");
+        }
+    }
+
+    private String uploadImageToS3(MultipartFile image) throws IOException {
+
+        String originalFilename = image.getOriginalFilename(); //원본 파일 명
+
+        String s3FileName = UUID.randomUUID().toString().substring(0, 10) + originalFilename; //S3에 저장될 파일명
+
+        ObjectMetadata metadata = new ObjectMetadata(); //파일에 대한 정보를 저장하는 객체
+        metadata.setContentType(image.getContentType());
+        metadata.setContentLength(image.getSize()); //파일의 크기 지정
+
+        try (InputStream inputStream = image.getInputStream()) {
+            PutObjectRequest putObjectRequest =
+                    new PutObjectRequest(bucket, s3FileName, inputStream, metadata)
+                            .withCannedAcl(CannedAccessControlList.PublicRead); //업로드한 파일이 공개적으로 읽힐 수 있도록 권한을 설정
+
+            amazonS3.putObject(putObjectRequest); //실제로 S3에 업로드
+        } catch (Exception e) {
+            throw new AmazonS3Exception("저장소에 이미지를 저장하는데 실패하였습니다.");
+        }
+
+        return amazonS3.getUrl(bucket, s3FileName).toString(); //S3에 저장된 파일 경로명 반환
+
+    }
+
+    public ImageResponseDTO deleteImg(CustomUserDetails customUserDetails, String imageAddress) {
+
+        User user = userService.findUserByUsernameOrThrow(customUserDetails.getUsername());
+
+        //imageAddress가 기본 이미지 경로명이면 key = null
+        String key = getKeyFromImageAddressBeforeUpdate(imageAddress);
+
+        if (key != null) {
+
+            try {
+                amazonS3.deleteObject(new DeleteObjectRequest(bucket, key));
+            } catch (Exception e) {
+                throw new AmazonS3Exception("저장소에 이미지를 삭제하는데 실패하였습니다.");
+            }
+
+        }
+
+        user.profileImg(DEFAULT_IMAGE_URL);
+
+        return ImageResponseDTO.builder()
+                .name(user.getName())
+                .profileImg(user.getProfileImg())
+                .build();
+    }
+
+    private String getKeyFromImageAddressBeforeUpdate(String imageAddress){
+
+        if (imageAddress.equals(DEFAULT_IMAGE_URL)) {
+            return null;
+        }
+
+        return getKeyFromImageAddress(imageAddress);
+    }
+
+    private String getKeyFromImageAddress(String imageAddress){
+
+        try{
+
+            URL url = new URL(imageAddress);
+
+            String decodingKey = URLDecoder.decode(url.getPath(), StandardCharsets.UTF_8);
+
+            return decodingKey.substring(1); // 맨 앞의 '/' 제거
+        }catch (MalformedURLException | StringIndexOutOfBoundsException e){
+            throw new IllegalArgumentException("해당 이미지를 찾을 수 없습니다.");
+        }
+    }
+
+
+
+}

--- a/src/main/java/com/culture/BAEUNDAY/domain/user/User.java
+++ b/src/main/java/com/culture/BAEUNDAY/domain/user/User.java
@@ -5,7 +5,7 @@ import com.culture.BAEUNDAY.domain.heart.Heart;
 import com.culture.BAEUNDAY.domain.reply.Reply;
 import jakarta.persistence.*;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import org.hibernate.annotations.DynamicInsert;
 
 import java.util.ArrayList;
@@ -13,7 +13,7 @@ import java.util.List;
 
 @Entity
 @Table(name = "user_tb")
-@Data
+@Getter
 @DynamicInsert
 public class User {
 
@@ -59,8 +59,15 @@ public class User {
         this.profileImg = profileImg;
     }
 
-    public void profileUpdate(String name, String field) {
+    public void profileImg(String profileImg) {
+        this.profileImg = profileImg;
+    }
+
+    public void profileName(String name) {
         this.name = name;
+    }
+
+    public void profileField(String field) {
         this.field = field;
     }
 

--- a/src/main/java/com/culture/BAEUNDAY/domain/user/UserController.java
+++ b/src/main/java/com/culture/BAEUNDAY/domain/user/UserController.java
@@ -1,9 +1,6 @@
 package com.culture.BAEUNDAY.domain.user;
 
-import com.culture.BAEUNDAY.domain.user.DTO.request.CheckRequestDTO;
-import com.culture.BAEUNDAY.domain.user.DTO.request.LoginDTO;
-import com.culture.BAEUNDAY.domain.user.DTO.request.RegisterRequestDTO;
-import com.culture.BAEUNDAY.domain.user.DTO.request.UpdateProfileRequestDTO;
+import com.culture.BAEUNDAY.domain.user.DTO.request.*;
 import com.culture.BAEUNDAY.domain.user.DTO.response.CheckNameResponseDTO;
 import com.culture.BAEUNDAY.domain.user.DTO.response.CheckUsernameResponseDTO;
 import com.culture.BAEUNDAY.jwt.Custom.CustomUserDetails;
@@ -13,9 +10,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Map;
 
@@ -28,6 +27,7 @@ public class UserController {
     private final UserService userService;
     private final LoginService loginService;
     private final LogoutService logoutService;
+    private final ImageService imageService;
 
     @PostMapping("/login")
     @Operation(summary = "로그인")
@@ -65,11 +65,25 @@ public class UserController {
         return ResponseEntity.ok(userService.checkProfile(customUserDetails));
     }
 
-    @PutMapping("/profile")
-    @Operation(summary = "내 프로필 정보 수정")
-    public ResponseEntity<?> updateProfile(@AuthenticationPrincipal CustomUserDetails customUserDetails,
-                                           @RequestBody @Valid UpdateProfileRequestDTO updateProfileRequestDTO) {
-        return ResponseEntity.ok(userService.updateProfile(customUserDetails, updateProfileRequestDTO));
+    @PostMapping("/login-check-name")
+    @Operation(summary = "로그인한 사용자의 닉네임 중복 확인")
+    public ResponseEntity<?> checkNameLogin(@RequestBody @Valid CheckRequestDTO checkRequestDTO,
+                                            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(userService.checkNameLogin(checkRequestDTO.checkname(), customUserDetails));
+    }
+
+    @PutMapping("/profile/name")
+    @Operation(summary = "로그인한 사용자의 닉네임 중복 확인 후 닉네임 변경")
+    public ResponseEntity<?> newName(@RequestBody @Valid UpdateNameRequestDTO updateNameRequestDTO,
+                                     @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(userService.updateName(updateNameRequestDTO.name(), customUserDetails));
+    }
+
+    @PutMapping("/profile/field")
+    @Operation(summary = "로그인한 사용자의 한 줄 소개 변경")
+    public ResponseEntity<?> newName(@RequestBody @Valid UpdateFieldRequestDTO updateFieldRequestDTO,
+                                     @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(userService.updateField(updateFieldRequestDTO.field(), customUserDetails));
     }
 
     @GetMapping("/profile/{user_id}")
@@ -85,11 +99,20 @@ public class UserController {
         return ResponseEntity.ok(userService.getPosts(customUserDetails));
     }
 
-    //사용자 이미지 수정 : 추후 작성
+    @PostMapping(value = "/profile/img/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "프로필 이미지 수정")
+    public ResponseEntity<?> s3Upload(@RequestParam String deleteImage,
+                                      @RequestPart(value = "image") MultipartFile image,
+                                      @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(imageService.uploadImg(customUserDetails, deleteImage, image));
+    }
 
-
-    //사용자 이미지 삭제(S3의 기본 이미지 경로명 반환해야 함) : 추후 작성
-
+    @DeleteMapping("/profile/img/delete")
+    @Operation(summary = "프로필 이미지 삭제")
+    public ResponseEntity<?> s3Delete(@RequestParam String image,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(imageService.deleteImg(customUserDetails, image));
+    }
 
 
 

--- a/src/main/java/com/culture/BAEUNDAY/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/culture/BAEUNDAY/exception/GlobalExceptionHandler.java
@@ -1,12 +1,11 @@
 package com.culture.BAEUNDAY.exception;
 
 
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.culture.BAEUNDAY.domain.chatGPT.GptController;
-import com.culture.BAEUNDAY.domain.heart.HeartRestController;
-import com.culture.BAEUNDAY.domain.post.PostRestController;
 import com.culture.BAEUNDAY.domain.comment.CommentController;
+import com.culture.BAEUNDAY.domain.post.PostRestController;
 import com.culture.BAEUNDAY.domain.reply.ReplyController;
-import com.culture.BAEUNDAY.domain.reserve.ReserveRestController;
 import com.culture.BAEUNDAY.domain.review.ReviewController;
 import com.culture.BAEUNDAY.domain.user.UserController;
 import jakarta.persistence.EntityNotFoundException;
@@ -17,22 +16,14 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 import java.nio.file.AccessDeniedException;
 import java.util.HashMap;
 import java.util.Map;
 
 
-@RestControllerAdvice(assignableTypes = {
-        UserController.class,
-        ReviewController.class,
-        PostRestController.class,
-        GptController.class,
-        CommentController.class,
-        ReplyController.class,
-        HeartRestController.class,
-        ReserveRestController.class
-})
+@RestControllerAdvice(assignableTypes = {UserController.class, ReviewController.class, PostRestController.class, GptController.class, CommentController.class, ReplyController.class})
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -56,6 +47,30 @@ public class GlobalExceptionHandler {
                 .build();
 
         return new ResponseEntity<>(errorResult, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MissingServletRequestPartException.class)
+    public ResponseEntity<ErrorResult> handleMissingServletRequestPartException(MissingServletRequestPartException ex) {
+
+        ErrorResult errorResult = ErrorResult.builder()
+                .status(400)
+                .message(ex.getRequestPartName() + "가 누락되었습니다.")
+                .errorCode("REQ_400")
+                .build();
+
+        return new ResponseEntity<>(errorResult, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(AmazonS3Exception.class)
+    public ResponseEntity<ErrorResult> handleAmazonS3Exception(AmazonS3Exception ex) {
+
+        ErrorResult errorResult = ErrorResult.builder()
+                .status(500)
+                .message(ex.getErrorMessage())
+                .errorCode("S3_ERROR")
+                .build();
+
+        return new ResponseEntity<>(errorResult, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @ExceptionHandler({UsernameNotFoundException.class, EntityNotFoundException.class})

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,24 @@ spring:
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 
+  servlet:
+    multipart:
+      max-file-size: 10MB  # 업로드할 수 있는 개별 파일의 최대 크기. 기본 1MB
+      max-request-size: 10MB # multipart/form-data 요청의 최대 허용 크기. 기본 10MB
+
+
+# AWS S3
+cloud:
+  aws:
+    credentials:
+      access-key: ${ACCESS_KEY}
+      secret-key: ${SECRET_KEY}
+    region:
+      static: ap-northeast-2
+    s3:
+      bucket: baeunday
+    stack:
+      auto: false
 
 #H2
 #spring:


### PR DESCRIPTION
# 💡 기능 설명

S3을 이용하여 이미지 업로드(수정) 및 삭제 구현 

# 💡 작업 상세 설명

아래 screenshot에서 말씀 드리겠습니다. 

# 📸 Screenshot

![image](https://github.com/user-attachments/assets/24677d18-514f-495d-94f7-62d03d4bad42)
회원가입 완료 시 응답으로 s3에 저장된 프로필 기본 이미지 경로명을 제공할 예정입니다.

프론트에서는 Conetent-Type : multipart/form-data 형식으로 보내줘야 하고 파라미터로 사용자의 기존 프로필 이미지 경로명(기본 이미지여도 보내줘야 함)도 보내주셔야합니다. 

form-data는 key : image / value : 수정할 이미지를 보내시면 됩니다. 

![image](https://github.com/user-attachments/assets/67f38fa8-5d67-4da7-8ccb-8a0b21ef8957)
위 그림은 파라미터가 기본 이미지 경로명인데 로직에는 기본 이미지 경로명일 경우 삭제하지 못하게 막아놨고 다른 이미지일 경우에는 s3에서 삭제하게 만들었습니다.  

그리고 form-data로 보낸 이미지로 업데이트 되게 마무리했습니다. (수정된 이미지는 s3에 저장됨)

![image](https://github.com/user-attachments/assets/0c4b1155-6d74-4899-99ce-7d7d2abf0af3)
다음과 같이 업데이트한 이미지의 경로명을 반환해줍니다.

![image](https://github.com/user-attachments/assets/f6771d48-80ad-4e05-8deb-d3ab72b5fee3)

프로필 이미지 삭제 시 사용자의 현재 이미지 경로명을 파라미터로 보내주셔야 됩니다 
근데 기본 이미지 경로명일 시 삭제 못하게 막아놨습니다.

![image](https://github.com/user-attachments/assets/1317271c-8c03-46df-b7de-030b6fb843fa)
이미지 삭제 후 기본 이미지 경로명으로 설정하고 응답합니다.

s3도 계속 확인해서 저장/삭제 잘 되는지 테스트 완료하였고 이상없습니다. 
특이사항이나 api 더 필요한 기능있으시면 말씀해주시면 감사하겠습니다. 

그리고 화요일에 s3 버킷이랑 키 값 주면 그 값으로 세팅해서 배포할 계획입니다. 

이상입니다. 
# 📢 Notes

제가 맡은 기능 구현은 끝났고 
남은 기간은 배포와 테스트 하는데 쓸 계획입니다.