### PR TITLE
feat/refactor: 리뷰 조회시 페이지네이션 구현 및 코드 수정

### DIFF
--- a/src/main/java/com/culture/BAEUNDAY/domain/comment/CommentController.java
+++ b/src/main/java/com/culture/BAEUNDAY/domain/comment/CommentController.java
@@ -3,6 +3,7 @@ package com.culture.BAEUNDAY.domain.comment;
 import com.culture.BAEUNDAY.domain.comment.DTO.request.CommentRequestDTO;
 import com.culture.BAEUNDAY.domain.comment.DTO.request.UpdateCommentRequestDTO;
 import com.culture.BAEUNDAY.jwt.Custom.CustomUserDetails;
+import com.culture.BAEUNDAY.utils.ApiUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -30,8 +31,9 @@ public class CommentController {
             @RequestParam(required = false) Long cursorId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
-        return ResponseEntity.ok(
-                commentService.getCommentsAndReplies(postId, cursor, cursorId, customUserDetails)
+
+        return ResponseEntity.ok(ApiUtils.success(
+                commentService.getCommentsAndReplies(postId, cursor, cursorId, customUserDetails))
         );
     }
 

--- a/src/main/java/com/culture/BAEUNDAY/domain/reply/ReplyService.java
+++ b/src/main/java/com/culture/BAEUNDAY/domain/reply/ReplyService.java
@@ -33,10 +33,9 @@ public class ReplyService {
         Comment ParentComment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 대댓글을 찾을 수 없습니다."));
 
-        //댓글을 작성한 사람 또는 게시글을 작성한 사람만 대댓글을 작성 가능
-        if ((!Objects.equals(ParentComment.getUser().getName(), user.getName())) &&
-            (!Objects.equals(ParentComment.getPost().getUser().getName(), user.getName()))) {
-            throw new AccessDeniedException("댓글 작성자 또는 게시글 작성자만 대댓글을 작성할 수 있습니다.");
+        //게시글을 작성한 사람만 대댓글을 작성 가능
+        if (!Objects.equals(ParentComment.getPost().getUser().getName(), user.getName())) {
+            throw new AccessDeniedException("게시글 작성자만 대댓글을 작성할 수 있습니다.");
 
         }
 

--- a/src/main/java/com/culture/BAEUNDAY/domain/user/DTO/response/RegisterResponseDTO.java
+++ b/src/main/java/com/culture/BAEUNDAY/domain/user/DTO/response/RegisterResponseDTO.java
@@ -8,7 +8,7 @@ public record RegisterResponseDTO(
         String name,
         String username,
         String profileImg,
-        Double manner
+        Integer manner
 ) {
 
 

--- a/src/main/java/com/culture/BAEUNDAY/domain/user/User.java
+++ b/src/main/java/com/culture/BAEUNDAY/domain/user/User.java
@@ -34,7 +34,7 @@ public class User {
     @Column(nullable = false)
     private Role role;
 
-    private Double manner = 36.5;
+    private Integer manner = 1000;
 
     private String field;
 

--- a/src/main/java/com/culture/BAEUNDAY/domain/user/UserController.java
+++ b/src/main/java/com/culture/BAEUNDAY/domain/user/UserController.java
@@ -1,7 +1,10 @@
 package com.culture.BAEUNDAY.domain.user;
 
+import com.culture.BAEUNDAY.domain.post.DTO.PostResponse;
 import com.culture.BAEUNDAY.domain.user.DTO.request.*;
 import com.culture.BAEUNDAY.jwt.Custom.CustomUserDetails;
+import com.culture.BAEUNDAY.utils.ApiUtils;
+import com.culture.BAEUNDAY.utils.PageResponse;
 import com.culture.BAEUNDAY.utils.s3.ImageService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -15,6 +18,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -94,8 +98,11 @@ public class UserController {
 
     @GetMapping("/profile/posts")
     @Operation(summary = "내가 작성한 글 조회")
-    public ResponseEntity<?> getPosts(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        return ResponseEntity.ok(userService.getPosts(customUserDetails));
+    public ResponseEntity<?> getPosts(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                     @RequestParam(value = "cursor", required = false) String cursor){
+            PageResponse<Long, List<PostResponse.PostDTO>> responseDTO = userService.getPosts(customUserDetails, cursor);
+
+        return ResponseEntity.ok(ApiUtils.success(responseDTO));
     }
 
     @PostMapping(value = "/profile/img/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/com/culture/BAEUNDAY/domain/user/UserRepository.java
+++ b/src/main/java/com/culture/BAEUNDAY/domain/user/UserRepository.java
@@ -1,6 +1,13 @@
 package com.culture.BAEUNDAY.domain.user;
 
+import com.culture.BAEUNDAY.domain.post.Post;
+import com.culture.BAEUNDAY.domain.review.Review;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
@@ -9,4 +16,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByUsername(String username);
 
     User findByUsername(String username);
+
+    @Query("select p from Post p where p.user.id = :userId and p.id < :cursor order by p.id desc ")
+    List<Post> findByUserIdWithCursor(@Param("userId") Long id, @Param("cursor") Long cursor, Pageable request);
 }


### PR DESCRIPTION
# 💡 기능 설명

"내가 작성한 글 조회" 커서 기반 페이지네이션 구현 

댓글과 대댓글 조회 시 응답 값 수정 

대댓글 작성 시 게시글 작성자만 작성하게 구현

매너 발자국 기본 값 36.5에서 1000으로 구현 

# 💡 작업 상세 설명

아래 스크린샷을 통해 설명하겠습니다.

# 📸 Screenshot

![image](https://github.com/user-attachments/assets/0ed86e23-26c3-4ac3-b12b-5a958cfdf98f)

"내가 작성한 글 조회" 커서 기반 페이지네이션 postId 내림차순 기준으로 구현하였습니다.

![image](https://github.com/user-attachments/assets/82d1306f-4b53-4a59-b216-fac866934b04)

댓글과 대댓글 조회 시 응답 값 "code" : 200 추가하였습니다. 

![image](https://github.com/user-attachments/assets/0114d549-ee0d-424f-903c-77dd88c955e4)

대댓글 작성 시 게시글 작성자만 작성할 수 있도록 구현하였습니다. 

![image](https://github.com/user-attachments/assets/49615adf-64a5-4f13-b72c-586a36724f53)

회원 가입 시 매너 발자국 36.5에서 1000으로 반환하게 설정하였습니다. 

# 📢 Notes

서버 구축, 유지보수 및 테스트 계속해서 진행할 예정 